### PR TITLE
Fix test failures on Go 1.11 and higher.

### DIFF
--- a/tlsrestrict_nss_tool/main.go
+++ b/tlsrestrict_nss_tool/main.go
@@ -59,7 +59,7 @@ var config = easyconfig.Configurator{
 	ProgramName: "tlsrestrict_nss_tool",
 }
 
-func init() {
+func parseConfig() {
 	err := config.Parse(nil)
 	if err != nil {
 		log.Fatalf("Couldn't parse configuration: %s", err)
@@ -78,6 +78,8 @@ func init() {
 }
 
 func main() {
+	parseConfig()
+
 	log.Info("Extracting CKBI certificate list")
 	CKBICerts, _, err := tlsrestrictnss.GetCKBICertList(
 		nssCKBIDirFlag.Value(), nssTempDirFlag.Value(),


### PR DESCRIPTION
Go 1.11 and higher execute the `init()` function when tests are run, even if no tests exist in the package.  This caused problems since `tlsrestrict_nss_tool`'s `init()` function produces errors when options aren't explicitly provided by the user via command-line flags or a config file.  See https://github.com/golang/go/issues/25789 for more info.  This commit moves that code from `init()` to `main()`.