### PR TITLE
Fix deleteCertWithNickname on Fedora 28

### DIFF
--- a/applyrestrictions.go
+++ b/applyrestrictions.go
@@ -217,7 +217,16 @@ func deleteCertWithNickname(nssDestDir, nickname string) (err error) {
 
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		if strings.Contains(string(stdoutStderr), "SEC_ERROR_UNRECOGNIZED_OID") {
+		// If the specified certificate is already not present in the
+		// NSS database, then we can safely ignore the error.
+		// Unfortunately, different NSS versions return a different
+		// error code for this case.  Older NSS versions (e.g. the
+		// version in Fedora 26) return SEC_ERROR_UNRECOGNIZED_OID,
+		// while newer NSS versions (e.g. the version in Fedora 28)
+		// return SEC_ERROR_INVALID_ARGS.  So we need to check for
+		// both.
+		if strings.Contains(string(stdoutStderr), "SEC_ERROR_UNRECOGNIZED_OID") ||
+			strings.Contains(string(stdoutStderr), "SEC_ERROR_INVALID_ARGS") {
 			log.Warn("Tried to delete certificate from NSS " +
 				"database, but the certificate was already " +
 				"not present in NSS database")

--- a/getcertlist.go
+++ b/getcertlist.go
@@ -246,21 +246,6 @@ func getDERFromMultiplePEM(certPEM []byte, certNickname, rootPrefix,
 	return validDER, nil
 }
 
-// GetOldCKBICertList gets a previously extracted list of CKBI certificates
-// from the file "old_ckbi_list.txt" in the specified directory.  (This
-// function is unused legacy code and may be removed at any time.)
-func GetOldCKBICertList(nssDir, rootPrefix, intermediatePrefix,
-	crossSignedPrefix string) (map[string]NSSCertificate, string,
-	error) {
-	allCertsText, err := ioutil.ReadFile(nssDir + "/old_ckbi_list.txt")
-	if err != nil {
-		return nil, "", fmt.Errorf("Error listing old certs: %s", err)
-	}
-
-	return parseCertList(nssDir, string(allCertsText), rootPrefix,
-		intermediatePrefix, crossSignedPrefix)
-}
-
 // GetCertList extracts the certificates from the NSS sqlite database in
 // nssDir.
 func GetCertList(nssDir, rootPrefix, intermediatePrefix,
@@ -350,6 +335,7 @@ func GetCKBICertList(nssCKBIDir, nssTempDir, rootPrefix, intermediatePrefix,
 }
 
 func enableCKBIVisibility(nssCKBIDir, nssDir string) error {
+	// #nosec G304
 	CKBILibrary, err := ioutil.ReadFile(nssCKBIDir + "/" + NSSCKBIName)
 	if err != nil {
 		return fmt.Errorf("Error reading CKBI: %s", err)


### PR DESCRIPTION
Recent versions of NSS use a different error code than before to indicate that a requested certificate nickname doesn't exist in the database.  This PR checks for the new error code in addition to the old error code.