### PR TITLE
travis: drop unsupported darwin/386, fixes test run

### DIFF
--- a/.travis/script
+++ b/.travis/script
@@ -34,7 +34,7 @@ GOX_PARA=3
 REPOS="github.com/$TRAVIS_REPO_SLUG/..."
 
 # non-cgo crosscompile
-gox -parallel=$GOX_PARA -osarch 'darwin/386 darwin/amd64 linux/386 linux/amd64 linux/arm linux/arm64 linux/ppc64 linux/ppc64le freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 netbsd/386 netbsd/amd64 netbsd/arm dragonfly/amd64 solaris/amd64 windows/386 windows/amd64' -output "$GOPATH/releasing/idist/tlsrestrictnss-$TRAVIS_TAG-{{.OS}}_{{.Arch}}/bin/{{.Dir}}" $REPOS
+gox -parallel=$GOX_PARA -osarch 'darwin/amd64 linux/386 linux/amd64 linux/arm linux/arm64 linux/ppc64 linux/ppc64le freebsd/386 freebsd/amd64 freebsd/arm openbsd/386 openbsd/amd64 netbsd/386 netbsd/amd64 netbsd/arm dragonfly/amd64 solaris/amd64 windows/386 windows/amd64' -output "$GOPATH/releasing/idist/tlsrestrictnss-$TRAVIS_TAG-{{.OS}}_{{.Arch}}/bin/{{.Dir}}" $REPOS
 RESULT2=$?
 
 echo non-cgo crosscompile exited with code $RESULT2


### PR DESCRIPTION
apple only supports amd64 , so it was dropped starting in go 1.12

this fixes the travis build

interesting related reading:
```
https://github.com/golang/go/issues/9511
https://github.com/golang/go/issues/37610
```
